### PR TITLE
Added ability to start/stop specific processes

### DIFF
--- a/lib/capistrano/tasks/supervisor.rake
+++ b/lib/capistrano/tasks/supervisor.rake
@@ -5,10 +5,31 @@ namespace :supervisord do
       execute "supervisorctl reload"
     end
   end
-  desc 'Restarts supervisord'
+
+  desc 'Restart supervisord process'
   task :restart do
     on roles fetch(:supervisord_restart_roles) do
-      execute "supervisorctl restart"
+      fetch(:supervisord_processes).each do |process|
+        execute "supervisorctl restart #{process}"
+      end
+    end
+  end
+
+  desc 'Start supervisord process'
+  task :start do
+    on roles fetch(:supervisord_restart_roles) do
+      fetch(:supervisord_processes).each do |process|
+        execute "supervisorctl start #{process}"
+      end
+    end
+  end
+
+  desc 'Stop supervisord process'
+  task :stop do
+    on roles fetch(:supervisord_restart_roles) do
+      fetch(:supervisord_processes).each do |process|
+        execute "supervisorctl stop #{process}"
+      end
     end
   end
 end
@@ -17,5 +38,6 @@ namespace :load do
   task :defaults do
     set :supervisord_reload_roles,      :app
     set :supervisord_restart_roles,     :app
+    set :supervisord_processes,         ['all']
   end
 end


### PR DESCRIPTION
This allows you to restart, start or stop specific supervisor processes. To use, set supervisord_processes. If you do not set this variable, it will restart/start/stop all processes.

Example:

set :supervisord_processes, %w{example-process1 example-process2}

after 'deploy:published', 'supervisord:stop'
after 'deploy:published', 'supervisord:start'
after 'deploy:published', 'supervisord:restart'
