### PR TITLE
Require rake in supervisor.rake

### DIFF
--- a/lib/capistrano/tasks/supervisor.rake
+++ b/lib/capistrano/tasks/supervisor.rake
@@ -1,3 +1,5 @@
+require 'rake'
+
 namespace :supervisord do
   desc 'Reloads supervisord'
   task :reload do


### PR DESCRIPTION
Rake file doesn't include rake tasks and brakes. 
Rails 5.2.0
Rake 12.3.1
Rspec 3.7.0

```
bundler: failed to load command: rspec (/usr/local/bundle/bin/rspec)
NoMethodError: undefined method `namespace' for main:Object
  /usr/local/bundle/gems/capistrano-supervisor-1.1.1/lib/capistrano/tasks/supervisor.rake:1:in `<top (required)>'
  /usr/local/bundle/gems/bootsnap-1.3.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:50:in `load'
  /usr/local/bundle/gems/bootsnap-1.3.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:50:in `load'
  /usr/local/bundle/gems/activesupport-5.2.0/lib/active_support/dependencies.rb:277:in `block in load'
  /usr/local/bundle/gems/activesupport-5.2.0/lib/active_support/dependencies.rb:249:in `load_dependency'
  /usr/local/bundle/gems/activesupport-5.2.0/lib/active_support/dependencies.rb:277:in `load'
  /usr/local/bundle/gems/capistrano-supervisor-1.1.1/lib/capistrano/supervisor.rb:1:in `<top (required)>'
  /usr/local/bundle/gems/bootsnap-1.3.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:71:in `require'
  /usr/local/bundle/gems/bootsnap-1.3.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:71:in `block in require_with_bootsnap_lfi'
  /usr/local/bundle/gems/bootsnap-1.3.0/lib/bootsnap/load_path_cache/loaded_features_index.rb:65:in `register'
  /usr/local/bundle/gems/bootsnap-1.3.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:70:in `require_with_bootsnap_lfi'
  /usr/local/bundle/gems/bootsnap-1.3.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:79:in `require'
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:95:in `rescue in block in require'
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:72:in `block in require'
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:65:in `each'
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:65:in `require'
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler.rb:114:in `require'
  /builds/CodeSynergium/ZeroKlik-Backend/config/application.rb:12:in `<top (required)>'
  /builds/CodeSynergium/ZeroKlik-Backend/config/environment.rb:2:in `require_relative'
  /builds/CodeSynergium/ZeroKlik-Backend/config/environment.rb:2:in `<top (required)>'
  /builds/CodeSynergium/ZeroKlik-Backend/spec/rails_helper.rb:4:in `require'
  /builds/CodeSynergium/ZeroKlik-Backend/spec/rails_helper.rb:4:in `<top (required)>'
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/configuration.rb:1455:in `require'
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/configuration.rb:1455:in `block in requires='
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/configuration.rb:1455:in `each'
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/configuration.rb:1455:in `requires='
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:112:in `block in process_options_into'
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:111:in `each'
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:111:in `process_options_into'
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:21:in `configure'
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:99:in `setup'
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:86:in `run'
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:71:in `run'
  /usr/local/bundle/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:45:in `invoke'
  /usr/local/bundle/gems/rspec-core-3.7.1/exe/rspec:4:in `<top (required)>'
  /usr/local/bundle/bin/rspec:29:in `load'
  /usr/local/bundle/bin/rspec:29:in `<top (required)>'
```